### PR TITLE
fix(config): Correct Next.js config syntax to fix build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,4 @@
-// next.config.js
 /** @type {import('next').NextConfig} */
+const nextConfig = {};
 
-
-const nextConfig = {
-};
-
-
-module.exports = nextConfig;
+export default nextConfig;


### PR DESCRIPTION
The `next.config.ts` file was using CommonJS `module.exports` syntax, but your project's `tsconfig.json` is configured for ES Modules. This syntax mismatch was causing the Next.js development server to fail to start properly.

Although this change doesn't directly reference the broken image, fixing the build process was the necessary step to allow the server to run and serve all static assets correctly, including the `seimei-eng.png` image on the landing page.